### PR TITLE
Remove PulsingCircle component from landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,6 @@
 
 import Header from "@/components/header"
 import HeroContent from "@/components/hero-content"
-import PulsingCircle from "@/components/pulsing-circle"
 import ShaderBackground from "@/components/shader-background"
 
 export default function ShaderShowcase() {
@@ -10,7 +9,6 @@ export default function ShaderShowcase() {
     <ShaderBackground>
       <Header />
       <HeroContent />
-      <PulsingCircle />
     </ShaderBackground>
   )
 }


### PR DESCRIPTION
## Summary
- Removed the PulsingCircle component from the bottom right of the landing page
- Cleaned up unused import in page.tsx
- Simplifies the landing page layout by removing the "v0 is amazing" rotating text element

## Test plan
- [x] Verify landing page renders without the bottom right pulsing circle
- [x] Check that shader background and other components remain functional
- [x] Ensure no console errors or broken imports

🤖 Generated with [Claude Code](https://claude.ai/code)